### PR TITLE
Generalize and improve threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ media_storage_providers:
   store_synchronous: True
   config:
     bucket: <S3_BUCKET_NAME>
+    # All of the below options are optional, for use with non-AWS S3-like
+    # services, or to specify access tokens here instead of some external method.
+    region_name: <S3_REGION_NAME>
+    endpoint_url: <S3_LIKE_SERVICE_ENDPOINT_URL>
+    access_key_id: <S3_ACCESS_KEY_ID>
+    secret_access_key: <S3_SECRET_ACCESS_KEY>
 ```
 
 This module uses `boto3`, and so the credentials should be specified as

--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -51,8 +51,18 @@ class S3StorageProviderBackend(StorageProvider):
         self.bucket = config["bucket"]
         self.storage_class = config["storage_class"]
         self.api_kwargs = {}
+
+        if "region_name" in config:
+            self.api_kwargs["region_name"] = config["region_name"]
+
         if "endpoint_url" in config:
             self.api_kwargs["endpoint_url"] = config["endpoint_url"]
+
+        if "access_key_id" in config:
+            self.api_kwargs["aws_access_key_id"] = config["access_key_id"]
+
+        if "secret_access_key" in config:
+            self.api_kwargs["aws_secret_access_key"] = config["secret_access_key"]
 
     def store_file(self, path, file_info):
         """See StorageProvider.store_file"""
@@ -95,8 +105,17 @@ class S3StorageProviderBackend(StorageProvider):
             "storage_class": storage_class,
         }
 
+        if "region_name" in config:
+            result["region_name"] = config["region_name"]
+
         if "endpoint_url" in config:
             result["endpoint_url"] = config["endpoint_url"]
+
+        if "access_key_id" in config:
+            result["access_key_id"] = config["access_key_id"]
+
+        if "secret_access_key" in config:
+            result["secret_access_key"] = config["secret_access_key"]
 
         return result
 

--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -125,7 +125,8 @@ class _S3DownloadThread(threading.Thread):
 
     Args:
         bucket (str): The S3 bucket which may have the file
-        api_kwargs (dict): Keyword arguments to pass when invoking the API. Generally `endpoint_url`.
+        api_kwargs (dict): Keyword arguments to pass when invoking the API.
+            Generally `endpoint_url`.
         key (str): The key of the file
         deferred (Deferred[_S3Responder|None]): If file exists
             resolved with an _S3Responder instance, if it doesn't

--- a/test_s3.py
+++ b/test_s3.py
@@ -18,7 +18,13 @@ from twisted.python.failure import Failure
 from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.trial import unittest
 
-from queue import Queue
+import sys
+is_py2 = sys.version[0] == '2'
+if is_py2:
+    from Queue import Queue
+else:
+    from queue import Queue
+
 from threading import Event, Thread
 
 from mock import Mock


### PR DESCRIPTION
This PR contains some commits by @srhoulam and @djmaze to make it possible to use this for non-AWS S3-like services, and improve thread safety.

Also added more config options to set region name and access tokens directly in the config instead of via CLI tools or environment variables when they are not as feasible to use.

This is similar to #13 but builds further on it and fixes the CI issues.