### PR TITLE
Use boto3 session from localdata.

### DIFF
--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -141,7 +141,10 @@ class _S3DownloadThread(threading.Thread):
         self.deferred = deferred
 
     def run(self):
-        session = boto3.session.Session()
+        local_data = threading.local()
+        if not hasattr(local_data, "b3_session"):
+            local_data.b3_session = boto3.session.Session()
+        session = local_data.b3_session
         s3 = session.client('s3', **self.api_kwargs)
 
         try:


### PR DESCRIPTION
This prevents issues when the thread-unsafe Session() is
used by multiple threads by allocating one in local_data.

(This has been tested on matrix.org)