### PR TITLE
Add intelligent tiering, only upload local files

### DIFF
--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -256,7 +256,7 @@ def run_upload(
             mark_as_deleted(sqlite_conn, origin, media_id)
             continue
 
-        if not check_file_in_s3(s3, bucket, rel_file_path):
+        if m_type == "local" and not check_file_in_s3(s3, bucket, rel_file_path):
             try:
                 s3.upload_file(
                     local_path,
@@ -394,6 +394,7 @@ def main():
             "REDUCED_REDUNDANCY",
             "STANDARD_IA",
             "ONEZONE_IA",
+            "INTELLIGENT_TIERING"
         ],
         default="STANDARD",
     )


### PR DESCRIPTION
Intelligent tiering support was added in ad979a6bead960c2058bacf818a3ee51a9153bcf, we need to support it in the upload script. Also we don't need to upload remote files, it's a waste of storage and money. We can always retrieve them from the servers of origin. I'm not sure if we even need to index them to the database. If there's a strong reason for that I might add an option to exclude/include the remote files from upload.

Signed-off-by: Sergey Shpikin <rkfg@rkfg.me>