### PR TITLE
Move to non-binary psycopg2 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'boto3>=1.9.23<2.0',
         'botocore>=1.12.23<2.0',
         'humanize>=0.5.1<0.6',
-        'psycopg2-binary>=2.7.5<3.0',
+        'psycopg2>=2.7.5<3.0',
         'PyYAML>=3.13<4.0',
         'tqdm>=4.26.0<5.0'
     ],


### PR DESCRIPTION
Because that's what synapse uses currently.