### PR TITLE
Fix upload script to handle media that has never been accessed

### DIFF
--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -63,7 +63,7 @@ def run_update_db(postgres_conn, sqlite_conn, before_date):
         SELECT '', media_id, media_id
         FROM local_media_repository
         WHERE
-            last_access_ts < %s
+            COALESCE(last_access_ts, created_ts) < %s
             AND url_cache IS NULL
     """
 
@@ -71,7 +71,7 @@ def run_update_db(postgres_conn, sqlite_conn, before_date):
         SELECT media_origin, media_id, filesystem_id
         FROM remote_media_cache
         WHERE
-            last_access_ts < %s
+            COALESCE(last_access_ts, created_ts) < %s
     """
 
     last_access_ts = int(before_date.timestamp() * 1000)


### PR DESCRIPTION
This is done by falling back to the `created_ts` if `last_access_ts` is null.

Fixes #45.