### PR TITLE
Add S3 endpoint url

### DIFF
--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -405,6 +405,12 @@ def main():
         help="Deletes local copy from media store on succesful upload",
     )
 
+    upload_parser.add_argument(
+        "--endpoint-url",
+        help="S3 endpoint url to use",
+        default=None
+    )
+
     args = parser.parse_args()
 
     if args.cmd == "write":
@@ -432,7 +438,7 @@ def main():
 
     if args.cmd == "upload":
         sqlite_conn = get_sqlite_conn(parser)
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", endpoint_url=args.endpoint_url)
         run_upload(
             s3,
             args.bucket,


### PR DESCRIPTION
This is to support S3-like services like B2 backblaze and DO Spaces, for example, because robocore/s3 cli doesn't provide a clear and easy way to encode this in the shared config file, the shared credentials file can be pointed to with a `AWS_SHARED_CREDENTIALS_FILE` environment variable, but an endpoint cant.

Previously I made this another endpoint variable, but I think this is a more ergonomic way of doing it.