### PR TITLE
Configure @matrix-org/synapse-core to be the code owner for the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request reviews from the synapse-core team when a pull request comes in.
+* @matrix-org/synapse-core


### PR DESCRIPTION
Signed-off-by: Sean Quah <seanq@element.io>