### PR TITLE
Test uploading to PyPI on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: "Build and upload to PyPI"
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.6"
+
+      - name: "Install packaging tools"
+        run: "python -m pip install --upgrade build twine"
+
+      - name: "Build dist package"
+        run: "python -m build"
+
+      - name: "Upload to PyPI"
+        run: "python -m twine --repository testpypi upload dist/*"
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: "${{ secrets.TESTPYPI_API_TOKEN }}"


### PR DESCRIPTION
I wrote out an action only to realise that it basically already existed [here](https://github.com/actions/starter-workflows/blob/da223f8a03b845b8624b144879658659a0b97d76/ci/python-publish.yml). Two key differences:

- we invoke twine directly, rather than using https://github.com/pypa/gh-action-pypi-publish
- this releases to the __test__ pypi instance

It's triggered when we make a release on github.

I tried to test this on `pull_request`, but I don't think it's possible to test a new workflow until it's been merged into main? Given that it's against the test instance, I suggest we screw it and commit it anyway.