### PR TITLE
Add support for synapse running on sqlite3 database in `scripts/s3_media_upload`

### DIFF
--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -32,7 +32,8 @@ progress = True
 
 
 def parse_duration(string):
-    """Parse a string into a duration supports suffix of d, m or y."""
+    """Parse a string into a duration supports suffix of d, m or y.
+    """
     suffix = string[-1]
     number = string[:-1]
 
@@ -68,7 +69,8 @@ def mark_as_deleted(sqlite_conn, origin, media_id):
 
 
 def get_not_deleted_count(sqlite_conn):
-    """Get count of all rows in our cache that we don't think have been deleted"""
+    """Get count of all rows in our cache that we don't think have been deleted
+    """
     cur = sqlite_conn.cursor()
 
     cur.execute(
@@ -82,7 +84,8 @@ def get_not_deleted_count(sqlite_conn):
 
 
 def get_not_deleted(sqlite_conn):
-    """Get all rows in our cache that we don't think have been deleted"""
+    """Get all rows in our cache that we don't think have been deleted
+    """
     cur = sqlite_conn.cursor()
 
     cur.execute(
@@ -95,7 +98,8 @@ def get_not_deleted(sqlite_conn):
 
 
 def to_path(origin, filesystem_id, m_type):
-    """Get a relative path to the given media"""
+    """Get a relative path to the given media
+    """
     if m_type == "local":
         file_path = os.path.join(
             "local_content", filesystem_id[:2], filesystem_id[2:4], filesystem_id[4:],
@@ -115,7 +119,8 @@ def to_path(origin, filesystem_id, m_type):
 
 
 def to_thumbnail_dir(origin, filesystem_id, m_type):
-    """Get a relative path to the given media's thumbnail directory"""
+    """Get a relative path to the given media's thumbnail directory
+    """
     if m_type == "local":
         thumbnail_path = os.path.join(
             "local_thumbnails",
@@ -138,7 +143,8 @@ def to_thumbnail_dir(origin, filesystem_id, m_type):
 
 
 def get_local_files(base_path, origin, filesystem_id, m_type):
-    """Get a list of relative paths to undeleted files for the given media"""
+    """Get a list of relative paths to undeleted files for the given media
+    """
     local_files = []
 
     original_path = to_path(origin, filesystem_id, m_type)
@@ -162,7 +168,8 @@ def get_local_files(base_path, origin, filesystem_id, m_type):
 
 
 def check_file_in_s3(s3, bucket, key):
-    """Check the file exists in S3 (though it could be different)"""
+    """Check the file exists in S3 (though it could be different)
+    """
     try:
         s3.head_object(Bucket=bucket, Key=key)
     except botocore.exceptions.ClientError as e:
@@ -174,7 +181,8 @@ def check_file_in_s3(s3, bucket, key):
 
 
 def run_write(sqlite_conn, output_file):
-    """Entry point for write command"""
+    """Entry point for write command
+    """
     for origin, _, filesystem_id, m_type in get_not_deleted(sqlite_conn):
         file_path = to_path(origin, filesystem_id, m_type)
         print(file_path, file=output_file)
@@ -186,7 +194,8 @@ def run_write(sqlite_conn, output_file):
 
 
 def run_update_db(synapse_db_conn, sqlite_conn, before_date):
-    """Entry point for update-db command"""
+    """Entry point for update-db command
+    """
 
     local_sql = """
         SELECT '', media_id, media_id
@@ -236,7 +245,8 @@ def run_update_db(synapse_db_conn, sqlite_conn, before_date):
 
 
 def update_db_process_rows(mtype, sqlite_cur, synapse_db_curs):
-    """Process rows extracted from Synapse's database and insert them in cache"""
+    """Process rows extracted from Synapse's database and insert them in cache
+    """
     update_count = 0
 
     for (origin, media_id, filesystem_id) in synapse_db_curs:
@@ -254,7 +264,8 @@ def update_db_process_rows(mtype, sqlite_cur, synapse_db_curs):
 
 
 def run_check_delete(sqlite_conn, base_path):
-    """Entry point for check-deleted command"""
+    """Entry point for check-deleted command
+    """
     deleted = []
     if progress:
         it = tqdm.tqdm(
@@ -284,7 +295,8 @@ def run_check_delete(sqlite_conn, base_path):
 
 
 def run_upload(s3, bucket, sqlite_conn, base_path, should_delete, storage_class):
-    """Entry point for upload command"""
+    """Entry point for upload command
+    """
     total = get_not_deleted_count(sqlite_conn)
 
     uploaded_media = 0
@@ -367,7 +379,8 @@ def run_upload(s3, bucket, sqlite_conn, base_path, should_delete, storage_class)
 
 
 def get_sqlite_conn(parser):
-    """Attempt to get a sqlite connection to cache.db, or exit."""
+    """Attempt to get a sqlite connection to cache.db, or exit.
+    """
     try:
         sqlite_conn = sqlite3.connect("cache.db")
         sqlite_conn.executescript(SCHEMA)

--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -32,8 +32,7 @@ progress = True
 
 
 def parse_duration(string):
-    """Parse a string into a duration supports suffix of d, m or y.
-    """
+    """Parse a string into a duration supports suffix of d, m or y."""
     suffix = string[-1]
     number = string[:-1]
 
@@ -69,8 +68,7 @@ def mark_as_deleted(sqlite_conn, origin, media_id):
 
 
 def get_not_deleted_count(sqlite_conn):
-    """Get count of all rows in our cache that we don't think have been deleted
-    """
+    """Get count of all rows in our cache that we don't think have been deleted"""
     cur = sqlite_conn.cursor()
 
     cur.execute(
@@ -84,8 +82,7 @@ def get_not_deleted_count(sqlite_conn):
 
 
 def get_not_deleted(sqlite_conn):
-    """Get all rows in our cache that we don't think have been deleted
-    """
+    """Get all rows in our cache that we don't think have been deleted"""
     cur = sqlite_conn.cursor()
 
     cur.execute(
@@ -98,8 +95,7 @@ def get_not_deleted(sqlite_conn):
 
 
 def to_path(origin, filesystem_id, m_type):
-    """Get a relative path to the given media
-    """
+    """Get a relative path to the given media"""
     if m_type == "local":
         file_path = os.path.join(
             "local_content", filesystem_id[:2], filesystem_id[2:4], filesystem_id[4:],
@@ -119,8 +115,7 @@ def to_path(origin, filesystem_id, m_type):
 
 
 def to_thumbnail_dir(origin, filesystem_id, m_type):
-    """Get a relative path to the given media's thumbnail directory
-    """
+    """Get a relative path to the given media's thumbnail directory"""
     if m_type == "local":
         thumbnail_path = os.path.join(
             "local_thumbnails",
@@ -143,8 +138,7 @@ def to_thumbnail_dir(origin, filesystem_id, m_type):
 
 
 def get_local_files(base_path, origin, filesystem_id, m_type):
-    """Get a list of relative paths to undeleted files for the given media
-    """
+    """Get a list of relative paths to undeleted files for the given media"""
     local_files = []
 
     original_path = to_path(origin, filesystem_id, m_type)
@@ -168,8 +162,7 @@ def get_local_files(base_path, origin, filesystem_id, m_type):
 
 
 def check_file_in_s3(s3, bucket, key):
-    """Check the file exists in S3 (though it could be different)
-    """
+    """Check the file exists in S3 (though it could be different)"""
     try:
         s3.head_object(Bucket=bucket, Key=key)
     except botocore.exceptions.ClientError as e:
@@ -181,8 +174,7 @@ def check_file_in_s3(s3, bucket, key):
 
 
 def run_write(sqlite_conn, output_file):
-    """Entry point for write command
-    """
+    """Entry point for write command"""
     for origin, _, filesystem_id, m_type in get_not_deleted(sqlite_conn):
         file_path = to_path(origin, filesystem_id, m_type)
         print(file_path, file=output_file)
@@ -194,8 +186,7 @@ def run_write(sqlite_conn, output_file):
 
 
 def run_update_db(synapse_db_conn, sqlite_conn, before_date):
-    """Entry point for update-db command
-    """
+    """Entry point for update-db command"""
 
     local_sql = """
         SELECT '', media_id, media_id
@@ -227,21 +218,25 @@ def run_update_db(synapse_db_conn, sqlite_conn, before_date):
             synapse_db_curs = synapse_db_conn.cursor()
             for sql, mtype in ((local_sql, "local"), (remote_sql, "remote")):
                 synapse_db_curs.execute(sql.replace("%s", "?"), (last_access_ts,))
-                update_count += update_db_process_rows(mtype, sqlite_cur, synapse_db_curs)
+                update_count += update_db_process_rows(
+                    mtype, sqlite_cur, synapse_db_curs
+                )
 
         else:
             with synapse_db_conn.cursor() as synapse_db_curs:
                 for sql, mtype in ((local_sql, "local"), (remote_sql, "remote")):
                     synapse_db_curs.execute(sql, (last_access_ts,))
-                    update_count += update_db_process_rows(mtype, sqlite_cur, synapse_db_curs)
+                    update_count += update_db_process_rows(
+                        mtype, sqlite_cur, synapse_db_curs
+                    )
 
     print("Synced", update_count, "new rows")
 
     synapse_db_conn.close()
 
+
 def update_db_process_rows(mtype, sqlite_cur, synapse_db_curs):
-    """Process rows extracted from Synapse's database and insert them in cache
-    """
+    """Process rows extracted from Synapse's database and insert them in cache"""
     update_count = 0
 
     for (origin, media_id, filesystem_id) in synapse_db_curs:
@@ -259,8 +254,7 @@ def update_db_process_rows(mtype, sqlite_cur, synapse_db_curs):
 
 
 def run_check_delete(sqlite_conn, base_path):
-    """Entry point for check-deleted command
-    """
+    """Entry point for check-deleted command"""
     deleted = []
     if progress:
         it = tqdm.tqdm(
@@ -290,8 +284,7 @@ def run_check_delete(sqlite_conn, base_path):
 
 
 def run_upload(s3, bucket, sqlite_conn, base_path, should_delete, storage_class):
-    """Entry point for upload command
-    """
+    """Entry point for upload command"""
     total = get_not_deleted_count(sqlite_conn)
 
     uploaded_media = 0
@@ -374,8 +367,7 @@ def run_upload(s3, bucket, sqlite_conn, base_path, should_delete, storage_class)
 
 
 def get_sqlite_conn(parser):
-    """Attempt to get a sqlite connection to cache.db, or exit.
-    """
+    """Attempt to get a sqlite connection to cache.db, or exit."""
     try:
         sqlite_conn = sqlite3.connect("cache.db")
         sqlite_conn.executescript(SCHEMA)

--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -193,7 +193,7 @@ def run_write(sqlite_conn, output_file):
         print(thumbnail_path, file=output_file)
 
 
-def run_update_db(postgres_conn, sqlite_conn, before_date):
+def run_update_db(synapse_db_conn, sqlite_conn, before_date):
     """Entry point for update-db command
     """
 
@@ -219,26 +219,43 @@ def run_update_db(postgres_conn, sqlite_conn, before_date):
     )
 
     update_count = 0
+
     with sqlite_conn:
         sqlite_cur = sqlite_conn.cursor()
-        with postgres_conn.cursor() as pg_curs:
-            for sql, mtype in ((local_sql, "local"), (remote_sql, "remote")):
-                pg_curs.execute(sql, (last_access_ts,))
 
-                for (origin, media_id, filesystem_id) in pg_curs:
-                    sqlite_cur.execute(
-                        """
-                        INSERT OR IGNORE INTO media
-                        (origin, media_id, filesystem_id, type, known_deleted)
-                        VALUES (?, ?, ?, ?, ?)
-                        """,
-                        (origin, media_id, filesystem_id, mtype, False),
-                    )
-                    update_count += sqlite_cur.rowcount
+        if isinstance(synapse_db_conn, sqlite3.Connection):
+            synapse_db_curs = synapse_db_conn.cursor()
+            for sql, mtype in ((local_sql, "local"), (remote_sql, "remote")):
+                synapse_db_curs.execute(sql.replace("%s", "?"), (last_access_ts,))
+                update_count += update_db_process_rows(mtype, sqlite_cur, synapse_db_curs)
+
+        else:
+            with synapse_db_conn.cursor() as synapse_db_curs:
+                for sql, mtype in ((local_sql, "local"), (remote_sql, "remote")):
+                    synapse_db_curs.execute(sql, (last_access_ts,))
+                    update_count += update_db_process_rows(mtype, sqlite_cur, synapse_db_curs)
 
     print("Synced", update_count, "new rows")
 
-    postgres_conn.close()
+    synapse_db_conn.close()
+
+def update_db_process_rows(mtype, sqlite_cur, synapse_db_curs):
+    """Process rows extracted from Synapse's database and insert them in cache
+    """
+    update_count = 0
+
+    for (origin, media_id, filesystem_id) in synapse_db_curs:
+        sqlite_cur.execute(
+            """
+            INSERT OR IGNORE INTO media
+            (origin, media_id, filesystem_id, type, known_deleted)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (origin, media_id, filesystem_id, mtype, False),
+        )
+        update_count += sqlite_cur.rowcount
+
+    return update_count
 
 
 def run_check_delete(sqlite_conn, base_path):
@@ -368,8 +385,9 @@ def get_sqlite_conn(parser):
     return sqlite_conn
 
 
-def get_postgres_conn(parser):
-    """Attempt to get a postgres connection based on database.yaml, or exit.
+def get_synapse_db_conn(parser):
+    """Attempt to get a connection based on database.yaml to Synapse's
+    database, or exit.
     """
     try:
         database_yaml = yaml.safe_load(open("database.yaml"))
@@ -379,11 +397,18 @@ def get_postgres_conn(parser):
         parser.error("database.yaml is not valid yaml: %s" % (e,))
 
     try:
-        postgres_conn = psycopg2.connect(**database_yaml)
+        if "sqlite" in database_yaml:
+            synapse_db_conn = sqlite3.connect(**database_yaml["sqlite"])
+        elif "postgres" in database_yaml:
+            synapse_db_conn = psycopg2.connect(**database_yaml["postgres"])
+        else:
+            synapse_db_conn = psycopg2.connect(**database_yaml)
+    except sqlite3.OperationalError as e:
+        parser.error("Could not connect to sqlite3 database: %s" % (e,))
     except psycopg2.Error as e:
         parser.error("Could not connect to postgres database: %s" % (e,))
 
-    return postgres_conn
+    return synapse_db_conn
 
 
 def main():
@@ -488,8 +513,8 @@ def main():
 
     if args.cmd == "update-db":
         sqlite_conn = get_sqlite_conn(parser)
-        postgres_conn = get_postgres_conn(parser)
-        run_update_db(postgres_conn, sqlite_conn, args.duration)
+        synapse_db_conn = get_synapse_db_conn(parser)
+        run_update_db(synapse_db_conn, sqlite_conn, args.duration)
         return
 
     if args.cmd == "check-deleted":
@@ -499,8 +524,8 @@ def main():
 
     if args.cmd == "update":
         sqlite_conn = get_sqlite_conn(parser)
-        postgres_conn = get_postgres_conn(parser)
-        run_update_db(postgres_conn, sqlite_conn, args.duration)
+        synapse_db_conn = get_synapse_db_conn(parser)
+        run_update_db(synapse_db_conn, sqlite_conn, args.duration)
         run_check_delete(sqlite_conn, args.base_path)
         return
 


### PR DESCRIPTION
As the title says, this PR makes the `s3_media_upload` script able to run against a homeserver that runs on an sqlite3 database.

The `database.yaml` file is now expected to be as follows for an sqlite database:

```yaml
sqlite:
  database: /path/to/homeserver.db
```

For a postgresql, the new syntax is:

```yaml
postgres:
  user: pguser
  password: pgpass
  database: pgdb
  host: pghost
  port: pgport
```

However the old syntax is also still suported so as not to break compatibility:

```yaml
user: pguser
password: pgpass
database: pgdb
host: pghost
port: pgport
```