### PR TITLE
Integration test s3 storage provider against latest synapse release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Setup minio
       run: |
         docker run -d -p 9000:9000 --name minio \
-                   -e "MINIO_ACCESS_KEY=access_key_id" \
-                   -e "MINIO_SECRET_KEY=secret_access_key" \
+                   -e "MINIO_ACCESS_KEY=my_access_key_id" \
+                   -e "MINIO_SECRET_KEY=my_secret_access_key" \
                    -v /tmp/data:/data \
                    -v /tmp/config:/root/.minio \
                    minio/minio server /data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+name: "integration-test"
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'releases/*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.x"
+    - name: Run synapse
+      uses: michaelkaye/setup-matrix-synapse@v0.4.0
+      with: 
+        uploadLogs: true
+        httpPort: 8008
+        customModules: "synapse-s3-storage-provider"
+        customConfig: |
+          registration_shared_secret: QuadraticPeach
+          media_storage_providers:
+            - module: s3_storage_provider.S3StorageProviderBackend
+              store_local: True
+              store_remote: True
+              store_synchronous: True
+              config:
+                bucket: s3-storage-provider-tester
+                endpoint_url: http://127.0.0.1:9000/
+                access_key_id: access_key_id
+                secret_access_key: secret_access_key
+    - name: Setup minio
+      run: |
+        docker run -d -p 9000:9000 --name minio \
+                   -e "MINIO_ACCESS_KEY=access_key_id" \
+                   -e "MINIO_SECRET_KEY=secret_access_key" \
+                   -v /tmp/data:/data \
+                   -v /tmp/config:/root/.minio \
+                   minio/minio server /data
+        export AWS_ACCESS_KEY_ID=access_key_id
+        export AWS_SECRET_ACCESS_KEY=secret_access_key
+        export AWS_EC2_METADATA_DISABLED=true
+
+        aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://s3-storage-provider-tester
+    - name: Confirm happy path case
+      run: |
+        set -x 
+        #Register and login 
+        synapse/env/bin/register_new_matrix_user -k QuadraticPeach -u test -p test --no-admin http://127.0.0.1:8008
+        access_token=`curl -q -XPOST -d '{"type":"m.login.password", "user":"test", "password":"test"}' "http://127.0.0.1:8008/_matrix/client/r0/login" | jq -r .access_token`
+        #Upload file to synapse
+        mxc=`curl -q -H "Authorization: Bearer $access_token" http://127.0.0.1:8008/_matrix/media/v3/upload --data-binary @s3_storage_provider.py | jq -r .content_uri`
+        server_name=`echo $mxc | sed 's^mxc://\(.*\)/.*^\1^'`
+        media_id=`echo $mxc | sed 's^mxc://.*/\(.*\)^\1^'`
+        #Downloading uploaded file
+        curl -q -o round_trip http://127.0.0.1:8008/_matrix/media/v3/download/${server_name}/${media_id}/
+        #Verify file against original
+        diff round_trip s3_storage_provider.py
+        #Verify file against minio data store
+        diff /tmp/data/s3-storage-provider-tester/local_content/*/*/* s3_storage_provider.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
               config:
                 bucket: s3-storage-provider-tester
                 endpoint_url: http://127.0.0.1:9000/
-                access_key_id: access_key_id
-                secret_access_key: secret_access_key
+                access_key_id: my_access_key_id
+                secret_access_key: my_secret_access_key
     - name: Setup minio
       run: |
         docker run -d -p 9000:9000 --name minio \
@@ -40,8 +40,8 @@ jobs:
                    -v /tmp/data:/data \
                    -v /tmp/config:/root/.minio \
                    minio/minio server /data
-        export AWS_ACCESS_KEY_ID=access_key_id
-        export AWS_SECRET_ACCESS_KEY=secret_access_key
+        export AWS_ACCESS_KEY_ID=my_access_key_id
+        export AWS_SECRET_ACCESS_KEY=my_secret_access_key
         export AWS_EC2_METADATA_DISABLED=true
 
         aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://s3-storage-provider-tester


### PR DESCRIPTION
Integration test the current s3 media provider by loading it into a synapse running in github actions.

I did this because I needed to be able to load and test a new module using the synapse action I wrote, and thought I should make sure I can test it on an existing module first, before trying to develop a new module using it, so decided to write an integration test for this module.

The test uses a GHA to setup a synapse with the module installed, then sets up a matching minio to fake being S3, runs a script that attempts to login and upload/download media, finally validating that the downloaded file and the file stored in minio match the uploaded file.