### PR TITLE
CI: Update to v1.0.1 of setup-matrix-synapse

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         python-version: "3.x"
     - name: Run synapse
-      uses: michaelkaye/setup-matrix-synapse@v0.4.0
+      uses: michaelkaye/setup-matrix-synapse@v1.0.1
       with: 
         uploadLogs: true
         httpPort: 8008


### PR DESCRIPTION
Required to be compatible with recently released synapse versions v1.56.0 or higher.

This would not be a spam vector as the server is not available on the public federation.