### PR TITLE
Fix "LoggingContext must be given either a name or a parent context" error

### DIFF
--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -266,6 +266,9 @@ class _S3Responder(Responder):
     """
 
     def __init__(self):
+        parent_logcontext = current_context()
+        with LoggingContext(parent_context=parent_logcontext):
+            logger.info("Responder For S3")
         # Triggered by responder when more data has been requested (or
         # stop_event has been triggered)
         self.wakeup_event = threading.Event()


### PR DESCRIPTION
Fixes #56 `LoggingContext must be given either a name or a parent context` by adding `LoggingContext()` and `logger.info()` with parent context in `LoggingContext()` at line 269 - 271