### PR TITLE
Fix dependencies syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ setup(
     py_modules=["s3_storage_provider"],
     scripts=["scripts/s3_media_upload"],
     install_requires=[
-        "boto3>=1.9.23<2.0",
-        "botocore>=1.12.23<2.0",
-        "humanize>=0.5.1<0.6",
-        "psycopg2>=2.7.5<3.0",
-        "PyYAML>=3.13<4.0",
-        "tqdm>=4.26.0<5.0",
+        "boto3>=1.9.23,<2.0",
+        "botocore>=1.12.23,<2.0",
+        "humanize>=0.5.1,<0.6",
+        "psycopg2>=2.7.5,<3.0",
+        "PyYAML>=3.13,<4.0",
+        "tqdm>=4.26.0,<5.0",
         "Twisted",
     ],
 )


### PR DESCRIPTION
Fixes #79

Tested by `pip install .` afterwards.

I have no idea if the upper bounds are necessary or if they'll introduce conflicts with synpapse's lockfile.