### PR TITLE
Fix a CI flake

### DIFF
--- a/test_s3.py
+++ b/test_s3.py
@@ -125,8 +125,7 @@ class StreamingProducerTestCase(unittest.TestCase):
         self.body.error(excp)
         self.wait_for_thread()
 
-        self.assertTrue(deferred.called)
-        self.assertIsInstance(deferred.result, Failure)
+        self.failureResultOf(deferred, Exception)
 
     def wait_for_thread(self):
         """Wait for something to call `callFromThread` and advance reactor


### PR DESCRIPTION
We need to consume the `Failure` in `test_error`, otherwise subsequent
tests will fail if the garbage collector runs during them.
