### PR TITLE
Deal with GHA deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
     name: "Build and check Python package"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
 
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "3.x"
 
@@ -63,7 +63,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: "actions/setup-python@v4"
         with:


### PR DESCRIPTION
Part of https://github.com/matrix-org/synapse/issues/14203.

Should fix warnings on https://github.com/matrix-org/synapse-s3-storage-provider/actions/runs/4564754760 but not those on https://github.com/matrix-org/synapse-s3-storage-provider/actions/runs/4564754768 ; would need to update https://github.com/michaelkaye/setup-matrix-synapse for that.