### PR TITLE
Add client side encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ media_storage_providers:
     # Default is AES256.
     #sse_customer_algo: <S3_SSEC_ALGO>
 
-    # Client Side Encryption
-    #cse_key: <CSE_KEY>
+    # Client Side Encryption master key
+    #cse_master_key: <CSE_MASTER_KEY>
 
     # The object storage class used when uploading files to the bucket.
     # Default is STANDARD.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ media_storage_providers:
     # Default is AES256.
     #sse_customer_algo: <S3_SSEC_ALGO>
 
+    # Client Side Encryption
+    #cse_key: <CSE_KEY>
+
     # The object storage class used when uploading files to the bucket.
     # Default is STANDARD.
     #storage_class: "STANDARD_IA"

--- a/encryption/__init__.py
+++ b/encryption/__init__.py
@@ -1,0 +1,1 @@
+from .client_side_encryption import ClientSideEncryption

--- a/encryption/client_side_encryption.py
+++ b/encryption/client_side_encryption.py
@@ -1,0 +1,39 @@
+import hashlib
+import aws_encryption_sdk
+from aws_encryption_sdk.identifiers import EncryptionKeyType, WrappingAlgorithm, CommitmentPolicy
+from aws_encryption_sdk.key_providers.raw import RawMasterKeyProvider
+from aws_encryption_sdk.internal.crypto.wrapping_keys import WrappingKey
+
+class ClientSideEncryption():
+    def __init__(self, master_key):
+        self._key_provider = FixedKeyProvider()
+        self._key_provider.set_master_key(master_key)
+        self._encryption_client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
+
+    def decrypt(self, source):
+        return self._encryption_client.stream(
+            mode='d',
+            source=source,
+            key_provider=self._key_provider
+        )
+
+    def encrypt(self, source):
+        return self._encryption_client.stream(
+              mode='e',
+              source=source,
+              key_provider=self._key_provider
+        )
+
+class FixedKeyProvider(RawMasterKeyProvider):
+    provider_id = "fixed"
+
+    def set_master_key(self, master_key):
+        self.master_key = hashlib.sha256(master_key.encode("utf-8")).digest()
+        self.add_master_key('')
+
+    def _get_raw_key(self, key_id):
+        return WrappingKey(
+            wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
+            wrapping_key=self.master_key,
+            wrapping_key_type=EncryptionKeyType.SYMMETRIC,
+        )

--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -87,6 +87,8 @@ class S3StorageProviderBackend(StorageProvider):
         self._s3_pool = ThreadPool(name="s3-pool", maxthreads=threadpool_size)
         self._s3_pool.start()
 
+        self._cse_key = config.get("cse_key")
+
         # Manually stop the thread pool on shutdown. If we don't do this then
         # stopping Synapse takes an extra ~30s as Python waits for the threads
         # to exit.
@@ -184,6 +186,9 @@ class S3StorageProviderBackend(StorageProvider):
             result["extra_args"]["SSECustomerAlgorithm"] = config.get(
                 "sse_customer_algo", "AES256"
             )
+    
+        if "cse_key" in config:
+            result
 
         return result
 

--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -31,11 +31,7 @@ from synapse.logging.context import LoggingContext, make_deferred_yieldable
 from synapse.rest.media.v1._base import Responder
 from synapse.rest.media.v1.storage_provider import StorageProvider
 
-import hashlib
-import aws_encryption_sdk
-from aws_encryption_sdk.identifiers import EncryptionKeyType, WrappingAlgorithm, CommitmentPolicy
-from aws_encryption_sdk.internal.crypto.wrapping_keys import WrappingKey
-from aws_encryption_sdk.key_providers.raw import RawMasterKeyProvider
+from encryption.client_side_encryption import ClientSideEncryption
 
 # Synapse 1.13.0 moved current_context to a module-level function.
 try:
@@ -93,10 +89,9 @@ class S3StorageProviderBackend(StorageProvider):
         self._s3_pool = ThreadPool(name="s3-pool", maxthreads=threadpool_size)
         self._s3_pool.start()
 
+        self._cse_client = None
         if "cse_master_key" in config:
-            self._cse_client = None
-            self._key_provider = None
-            self._cse_master_key = config["cse_master_key"]
+            self._cse_client = ClientSideEncryption(config["cse_master_key"])
 
         # Manually stop the thread pool on shutdown. If we don't do this then
         # stopping Synapse takes an extra ~30s as Python waits for the threads
@@ -132,7 +127,7 @@ class S3StorageProviderBackend(StorageProvider):
 
         def _store_file():
             with LoggingContext(parent_context=parent_logcontext):
-                if self._cse_master_key:
+                if self._cse_client:
                     self.store_with_client_side_encryption(path)
                 else:
                     self._get_s3_client().upload_file(
@@ -147,32 +142,16 @@ class S3StorageProviderBackend(StorageProvider):
         )
     
     def store_with_client_side_encryption(self, path):
-        client = self.aws_encryption_client()
         s3_client = self._get_s3_client()
         file_name = os.path.join(self.cache_directory, path)
         with open(file_name, 'rb') as file:
-            with client.stream(
-              mode='e',
-              source=file,
-              key_provider=self.client_side_key_provider()
-            ) as encryptor:
+            with self._cse_client.encrypt(file) as encryptor:
                 s3_client.upload_fileobj(
                     Fileobj=encryptor, 
                     Bucket=self.bucket, 
                     Key=path,
                     ExtraArgs=self.extra_args)
 
-    def aws_encryption_client(self):
-        if self._cse_client:
-            return self._cse_client
-        self._cse_client = aws_encryption_sdk.EncryptionSDKClient(commitment_policy=CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT)
-        return self._cse_client
-
-    def client_side_key_provider(self):
-        if self._key_provider: return self._key_provider
-        self._key_provider = FixedKeyProvider()
-        self._key_provider.set_master_key(self._cse_master_key)
-        return self._key_provider
 
     def fetch(self, path, file_info):
         """See StorageProvider.fetch"""
@@ -293,7 +272,7 @@ def _stream_to_producer(reactor, producer, body, s3, status=None, timeout=None):
         status = _ProducerStatus()
 
     try:
-        if s3._cse_master_key:
+        if s3._cse_client:
             stream_body_with_cse(body, producer, reactor, s3, timeout, status)
         else:
             stream_body(body, producer, reactor, status, timeout)
@@ -337,12 +316,7 @@ def stream_body_with_cse(body, producer, reactor, s3, timeout, status):
     wakeup_event = producer.wakeup_event
     # Set if we should stop producing forever
     stop_event = producer.stop_event
-
-    with s3.aws_encryption_client().stream(
-            mode='d',
-            source=body,
-            key_provider=s3.client_side_key_provider()
-    ) as decryptor:
+    with s3._cse_client.decrypt(body) as decryptor:
         for chunk in decryptor:
             # We wait for the producer to signal that the consumer wants
             # more data (or we should abort)
@@ -461,17 +435,3 @@ class _ProducerStatus(object):
             self.is_paused.set()
         else:
             self.is_paused.clear()
-
-class FixedKeyProvider(RawMasterKeyProvider):
-    provider_id = "fixed"
-
-    def set_master_key(self, master_key):
-        self.master_key = hashlib.sha256(master_key.encode("utf-8")).digest()
-        self.add_master_key('')
-
-    def _get_raw_key(self, key_id):
-        return WrappingKey(
-            wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
-            wrapping_key=self.master_key,
-            wrapping_key_type=EncryptionKeyType.SYMMETRIC,
-        )

--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -11,6 +11,11 @@ import psycopg2
 import tqdm
 import yaml
 
+import sys
+sys.path.append(os.path.join(sys.path[0], '../'))
+from encryption.client_side_encryption import ClientSideEncryption
+
+
 # Schema for our sqlite database cache
 SCHEMA = """
     CREATE TABLE IF NOT EXISTS media (
@@ -302,7 +307,7 @@ def run_check_delete(sqlite_conn, base_path):
     print("Updated", len(deleted), "as deleted")
 
 
-def run_upload(s3, bucket, sqlite_conn, base_path, extra_args, should_delete):
+def run_upload(s3, bucket, sqlite_conn, base_path, extra_args, should_delete, cse_master_key):
     """Entry point for upload command
     """
     total = get_not_deleted_count(sqlite_conn)
@@ -332,14 +337,25 @@ def run_upload(s3, bucket, sqlite_conn, base_path, extra_args, should_delete):
         media_uploaded_files = 0
         media_deleted_files = 0
 
+        if cse_master_key:
+            cse_client = ClientSideEncryption('x')
+
         for rel_file_path in local_files:
             local_path = os.path.join(base_path, rel_file_path)
 
             if not check_file_in_s3(s3, bucket, rel_file_path, extra_args):
                 try:
-                    s3.upload_file(
-                        local_path, bucket, rel_file_path, ExtraArgs=extra_args,
-                    )
+                    if cse_master_key:
+                        with cse_client.encrypt as encryptor:
+                            s3.upload_fileobj(
+                                Fileobj=encryptor, 
+                                Bucket=bucket, 
+                                Key=rel_file_path,
+                                ExtraArgs=extra_args)
+                    else:
+                        s3.upload_file(
+                            local_path, bucket, rel_file_path, ExtraArgs=extra_args,
+                        )
                 except Exception as e:
                     print("Failed to upload file %s: %s", local_path, e)
                     continue
@@ -613,6 +629,7 @@ def main():
             args.base_path,
             extra_args,
             should_delete=args.delete,
+            cse_master_key=args.cse_master_key
         )
         return
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ setup(
         "psycopg2>=2.7.5,<3.0",
         "PyYAML>=5.4,<7.0",
         "tqdm>=4.26.0,<5.0",
+        "cryptography>=2.5.0",
+        "aws-encryption-sdk>=3.1.1",
         "Twisted",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     py_modules=["s3_storage_provider"],
+    packages=["encryption"],
     scripts=["scripts/s3_media_upload"],
     install_requires=[
         "boto3>=1.9.23,<2.0",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ deps =
     boto3
     mock
     matrix-synapse
+    aws-encryption-sdk
+    cryptography
 
 setenv =
     PYTHONDONTWRITEBYTECODE = no_byte_code


### PR DESCRIPTION
This PR extends the encryption options to include client side encryption. Using a static master key defined in the configuration `aws-encryption-sdk` library generates a key per file, encrypts the file with the generated key and encrypts both file and the key using the master key.