### PR TITLE
Remove empty LoggingContext

### DIFF
--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -332,8 +332,7 @@ class _S3Responder(Responder):
         self.stop_event.set()
         self.wakeup_event.set()
         if not self.deferred.called:
-            with LoggingContext():
-                self.deferred.errback(Exception("Consumer ask to stop producing"))
+            self.deferred.errback(Exception("Consumer ask to stop producing"))
 
     def _write(self, chunk):
         """Writes the chunk of data to consumer. Called by _S3DownloadThread.


### PR DESCRIPTION
As per the comments by @richvdh: https://github.com/matrix-org/synapse-s3-storage-provider/issues/56#issuecomment-1103873051 and https://github.com/matrix-org/synapse-s3-storage-provider/issues/56#issuecomment-1224184350

I've had this change in my own fork for a long time now and haven't noticed any issue with my Synapse instance, certainly no error logs about the LoggingContext.

This fixes #56 and supersedes #74 (the latter PR changes the `LoggingContext` instead of just removing it).

In turn, fixing this `LoggingContext` issue makes it start to log what actually happens when this code is hit, the whole "Consumer ask to stop producing". For that issue I'm not sure what the fix would be though. Is this just about the storage provider trying to provide a file to a client that no longer has a connection? That error line happens regularly in my logs.