### PR TITLE
Support using a prefix of the S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ media_storage_providers:
     # Default is STANDARD.
     #storage_class: "STANDARD_IA"
 
+    # Prefix for all media in bucket, can't be changed once media has been uploaded
+    # Useful if sharing the bucket between Synapses
+    # Blank if not provided
+    #prefix: "prefix/to/files/in/bucket"
+
     # The maximum number of concurrent threads which will be used to connect
     # to S3. Each thread manages a single connection. Default is 40.
     #
@@ -91,4 +96,3 @@ For maintainers:
 1. Update the `__version__` in setup.py. Commit. Push.
 2. Create a release on GitHub for this version.
 3. When published, a [GitHub action workflow](https://github.com/matrix-org/synapse-s3-storage-provider/actions/workflows/release.yml) will build the package and upload to [PyPI](https://pypi.org/project/synapse-s3-storage-provider/).
-

--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -302,7 +302,7 @@ def run_check_delete(sqlite_conn, base_path):
     print("Updated", len(deleted), "as deleted")
 
 
-def run_upload(s3, bucket, sqlite_conn, base_path, extra_args, should_delete):
+def run_upload(s3, bucket, sqlite_conn, base_path, s3_prefix, extra_args, should_delete):
     """Entry point for upload command
     """
     total = get_not_deleted_count(sqlite_conn)
@@ -335,10 +335,11 @@ def run_upload(s3, bucket, sqlite_conn, base_path, extra_args, should_delete):
         for rel_file_path in local_files:
             local_path = os.path.join(base_path, rel_file_path)
 
-            if not check_file_in_s3(s3, bucket, rel_file_path, extra_args):
+            key = s3_prefix + rel_file_path
+            if not check_file_in_s3(s3, bucket, key, extra_args):
                 try:
                     s3.upload_file(
-                        local_path, bucket, rel_file_path, ExtraArgs=extra_args,
+                        local_path, bucket, key, ExtraArgs=extra_args,
                     )
                 except Exception as e:
                     print("Failed to upload file %s: %s", local_path, e)
@@ -531,6 +532,8 @@ def main():
     )
     upload_parser.add_argument("bucket", help="S3 bucket to upload to")
 
+    upload_parser.add_argument("--prefix", help="Prefix of files in the bucket", default="")
+
     upload_parser.add_argument(
         "--storage-class",
         help="S3 storage class to use",
@@ -611,6 +614,7 @@ def main():
             args.bucket,
             sqlite_conn,
             args.base_path,
+            args.prefix,
             extra_args,
             should_delete=args.delete,
         )


### PR DESCRIPTION
People may want to use the S3 provider to upload files to a specific part of a bucket so that the same bucket can be shared between multiple Synapses without the potential for clashing ids for content