### PR TITLE
Bump humanize to work-around https://github.com/pypa/setuptools/issues/4519

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "boto3>=1.9.23,<2.0",
         "botocore>=1.31.62,<2.0",
-        "humanize>=0.5.1,<0.6",
+        "humanize>=4.0,<5.0",
         "psycopg2>=2.7.5,<3.0",
         "PyYAML>=5.4,<7.0",
         "tqdm>=4.26.0,<5.0",


### PR DESCRIPTION
We're seeing installation of the S3 storage provider fail with the following when using a recent pip/setuptools:
```
Collecting humanize<0.6,>=0.5.1 (from synapse-s3-storage-provider==1.4.0)
  Downloading humanize-0.5.1.tar.gz (14 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [39 lines of output]
      /usr/local/lib/python3.11/site-packages/setuptools/dist.py:447: SetuptoolsDeprecationWarning: Invalid dash-separated options
      !!
      
              ********************************************************************************
              Usage of dash-separated 'upload-dir' will not be supported in future
              versions. Please use the underscore name 'upload_dir' instead.
      
              By 2024-Sep-26, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
      
              See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
              ********************************************************************************
      
      !!
        opt = self.warn_dash_deprecation(opt, section)
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-a7crpkz6/humanize_3ef5a456510341f0ae52d55ae1140165/setup.py", line 15, in <module>
          setup(
        File "/usr/local/lib/python3.11/site-packages/setuptools/__init__.py", line 108, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 146, in setup
          _setup_distribution = dist = klass(attrs)
                                       ^^^^^^^^^^^^
        File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 278, in __init__
          _Distribution.__init__(self, dist_attrs)
        File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 286, in __init__
          self.finalize_options()
        File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 630, in finalize_options
          ep(self)
        File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 650, in _finalize_setup_keywords
          ep.load()(self, ep.name, value)
          ^^^^^^^^^
        File "/usr/local/lib/python3.11/importlib/metadata/__init__.py", line 204, in load
          return functools.reduce(getattr, attrs, module)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'setuptools.dist' has no attribute 'check_test_suite'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

Bump `humanize` to 4.x that's the first version where `setup.py` is mostly nuked and at somepoint in the 4.x series it disappears. The only usage of `humanize` in this repo is  2x `humanize.naturalsize(<some bytes>, gnu=True)` which is still supported in 4.x - https://python-humanize.readthedocs.io/en/latest/#file-size-humanization