### PR TITLE
Add support for session_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ media_storage_providers:
     endpoint_url: <S3_LIKE_SERVICE_ENDPOINT_URL>
     access_key_id: <S3_ACCESS_KEY_ID>
     secret_access_key: <S3_SECRET_ACCESS_KEY>
+    session_token: <S3_SESSION_TOKEN>
 
     # Server Side Encryption for Customer-provided keys
     #sse_customer_key: <S3_SSEC_KEY>

--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -81,6 +81,9 @@ class S3StorageProviderBackend(StorageProvider):
         if "secret_access_key" in config:
             self.api_kwargs["aws_secret_access_key"] = config["secret_access_key"]
 
+        if "session_token" in config:
+            self.api_kwargs["aws_session_token"] = config["session_token"]
+
         self._s3_client = None
         self._s3_client_lock = threading.Lock()
 
@@ -180,6 +183,9 @@ class S3StorageProviderBackend(StorageProvider):
 
         if "secret_access_key" in config:
             result["secret_access_key"] = config["secret_access_key"]
+
+        if "session_token" in config:
+            result["session_token"] = config["session_token"]
 
         if "sse_customer_key" in config:
             result["extra_args"]["SSECustomerKey"] = config["sse_customer_key"]


### PR DESCRIPTION
Temporary S3 credentials generated by **STS** (Security Token Service) need to set **session_token** in addition to **access_key_id** and **secret_access_key**.

This PR add support for configuring **session_token**.