### PR TITLE
Cast access key and secret access key to string

### DIFF
--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -173,7 +173,7 @@ class S3StorageProviderBackend(StorageProvider):
         }
 
         if "region_name" in config:
-            result["region_name"] = config["region_name"]
+            result["region_name"] = str(config["region_name"])
 
         if "endpoint_url" in config:
             result["endpoint_url"] = config["endpoint_url"]
@@ -182,7 +182,7 @@ class S3StorageProviderBackend(StorageProvider):
             result["access_key_id"] = str(config["access_key_id"])
 
         if "secret_access_key" in config:
-            result["secret_access_key"] = str(config["secret_access_key"])
+            result["secret_access_key"] = config["secret_access_key"]
 
         if "session_token" in config:
             result["session_token"] = config["session_token"]

--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -179,10 +179,10 @@ class S3StorageProviderBackend(StorageProvider):
             result["endpoint_url"] = config["endpoint_url"]
 
         if "access_key_id" in config:
-            result["access_key_id"] = config["access_key_id"]
+            result["access_key_id"] = str(config["access_key_id"])
 
         if "secret_access_key" in config:
-            result["secret_access_key"] = config["secret_access_key"]
+            result["secret_access_key"] = str(config["secret_access_key"])
 
         if "session_token" in config:
             result["session_token"] = config["session_token"]


### PR DESCRIPTION
If either of these values is not a string (an integer) then this will cause an error within the botocore auth/signature code.

[The source of the error within botocore](https://github.com/boto/botocore/blob/develop/botocore/auth.py#L384-L390):
```
 def scope(self, request):
        scope = [self.credentials.access_key]
        scope.append(request.context['timestamp'][0:8])
        scope.append(self._region_name)
        scope.append(self._service_name)
        scope.append('aws4_request')
        return '/'.join(scope)
```

This is really only a problem when you are using a s3 mocking service like `moto` or `localstack` as they allow you to specify the AWS Account ID via the access key name (which is then an integer). 

So if you happen to not explicitly quote the access_key_id field in the yaml file it is parsed as an `int` and then passed along unchanged to `boto3` which then does no further checks on it until it tries to `"/".join` it which causes an error because it is not a string.

A problematic config yaml:
```
media_storage_providers:
  - module: s3_storage_provider.S3StorageProviderBackend
    store_local: True
    store_remote: True
    store_synchronous: True
    config:
      bucket: matrix-s3-media-bucket
      endpoint_url: http://mock-aws:6789
      access_key_id: 112233445566
      secret_access_key: test
```

This error then occurs when trying to upload a file to s3
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/s3transfer/tasks.py", line 135, in __call__
    return self._execute_main(kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/s3transfer/tasks.py", line 158, in _execute_main
    return_value = self._main(**kwargs)
                   ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/s3transfer/upload.py", line 762, in _main
    client.put_object(Bucket=bucket, Key=key, Body=body, **extra_args)
  File "/usr/local/lib/python3.12/site-packages/botocore/client.py", line 569, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/client.py", line 1005, in _make_api_call
    http, parsed_response = self._make_request(
                            ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/client.py", line 1029, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/endpoint.py", line 119, in make_request
    return self._send_request(request_dict, operation_model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/endpoint.py", line 196, in _send_request
    request = self.create_request(request_dict, operation_model)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/endpoint.py", line 132, in create_request
    self._event_emitter.emit(
  File "/usr/local/lib/python3.12/site-packages/botocore/hooks.py", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/hooks.py", line 256, in emit
    return self._emit(event_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/hooks.py", line 239, in _emit
    response = handler(**kwargs)
               ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/signers.py", line 105, in handler
    return self.sign(operation_name, request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/signers.py", line 197, in sign
    auth.add_auth(request)
  File "/usr/local/lib/python3.12/site-packages/botocore/auth.py", line 438, in add_auth
    self._inject_signature_to_request(request, signature)
  File "/usr/local/lib/python3.12/site-packages/botocore/auth.py", line 441, in _inject_signature_to_request
    auth_str = [f'AWS4-HMAC-SHA256 Credential={self.scope(request)}']
                                               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/auth.py", line 390, in scope
    return '/'.join(scope)
           ^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, int found
```

If you ensure that the region and access_key_id are strings then this error won't occur.