### PR TITLE
Fix integration test CI: use auth'd media

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,10 @@ jobs:
     - name: Run synapse
       uses: michaelkaye/setup-matrix-synapse@v1.0.5
       with: 
-        uploadLogs: true
+        # This is turned off as it currently breaks runs. Can be re-enabled once
+        # `setup-matrix-synapse` updates its `@actions/artifact` updates to
+        # v2.x.
+        uploadLogs: false
         httpPort: 8008
         customModules: "synapse-s3-storage-provider"
         customConfig: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         python-version: "3.x"
     - name: Run synapse
-      uses: michaelkaye/setup-matrix-synapse@v1.0.1
+      uses: michaelkaye/setup-matrix-synapse@v1.0.5
       with: 
         uploadLogs: true
         httpPort: 8008

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       uses: michaelkaye/setup-matrix-synapse@v1.0.5
       with: 
         # This is turned off as it currently breaks runs. Can be re-enabled once
-        # `setup-matrix-synapse` updates its `@actions/artifact` updates to
+        # `setup-matrix-synapse` updates its `@actions/artifact` to
         # v2.x. See https://github.com/michaelkaye/setup-matrix-synapse/issues/102
         uploadLogs: false
         httpPort: 8008

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       with: 
         # This is turned off as it currently breaks runs. Can be re-enabled once
         # `setup-matrix-synapse` updates its `@actions/artifact` updates to
-        # v2.x.
+        # v2.x. See https://github.com/michaelkaye/setup-matrix-synapse/issues/102
         uploadLogs: false
         httpPort: 8008
         customModules: "synapse-s3-storage-provider"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         server_name=`echo $mxc | sed 's^mxc://\(.*\)/.*^\1^'`
         media_id=`echo $mxc | sed 's^mxc://.*/\(.*\)^\1^'`
         #Downloading uploaded file
-        curl -q -o round_trip http://127.0.0.1:8008/_matrix/media/v3/download/${server_name}/${media_id}/
+        curl -q -o round_trip -H "Authorization: Bearer $access_token" http://127.0.0.1:8008/_matrix/client/v1/media/download/${server_name}/${media_id}
         #Verify file against original
         diff round_trip s3_storage_provider.py
         #Verify file against minio data store


### PR DESCRIPTION
The previous CI was uploading media to an instance of Synapse with authenticated media enabled. This meant that all unauthenticated attempts to download media would result in a 404.

Switch the CI to using the new authenticated endpoint, and authenticate the request.