### PR TITLE
Set Synapse `uploadLogs` back to `true` for integration test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,9 @@ jobs:
       with:
         python-version: "3.x"
     - name: Run synapse
-      uses: michaelkaye/setup-matrix-synapse@v1.0.5
+      uses: michaelkaye/setup-matrix-synapse@v1.0.6
       with: 
-        # This is turned off as it currently breaks runs. Can be re-enabled once
-        # `setup-matrix-synapse` updates its `@actions/artifact` to
-        # v2.x. See https://github.com/michaelkaye/setup-matrix-synapse/issues/102
-        uploadLogs: false
+        uploadLogs: true
         httpPort: 8008
         customModules: "synapse-s3-storage-provider"
         customConfig: |


### PR DESCRIPTION
`v1.0.6` of michaelkaye/setup-matrix-synapse should now fix the issue with uploading logs:
https://github.com/michaelkaye/setup-matrix-synapse/issues/102

Thanks for the swift fix @michaelkaye :heart: 