### PR TITLE
Remove uploaded file from Synapse's local storage during integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,9 @@ jobs:
         mxc=`curl -q -H "Authorization: Bearer $access_token" http://127.0.0.1:8008/_matrix/media/v3/upload --data-binary @s3_storage_provider.py | jq -r .content_uri`
         server_name=`echo $mxc | sed 's^mxc://\(.*\)/.*^\1^'`
         media_id=`echo $mxc | sed 's^mxc://.*/\(.*\)^\1^'`
+        #Upload the file to S3 and delete from Synapse's local store. This forces retrieval from S3 on download.
+        synapse/env/bin/s3_media_upload --no-progress update --homeserver-config-path synapse/homeserver.yaml /tmp/data 0d
+        synapse/env/bin/s3_media_upload --no-progress upload --delete --endpoint-url http://127.0.0.1:9000/ /tmp/data s3-storage-provider-tester
         #Downloading uploaded file
         curl -q -o round_trip -H "Authorization: Bearer $access_token" http://127.0.0.1:8008/_matrix/client/v1/media/download/${server_name}/${media_id}
         #Verify file against original

--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -143,16 +143,14 @@ class S3StorageProviderBackend(StorageProvider):
         # We do, however, need to wrap in `run_in_background` to ensure that the
         # coroutine returned by `defer_to_threadpool` is used, and therefore
         # actually run.
-        self._module_api.run_in_background(
-            self._module_api.defer_to_threadpool(
-                self._s3_pool,
-                s3_download_task,
-                self._get_s3_client(),
-                self.bucket,
-                self.prefix + path,
-                self.extra_args,
-                d,
-            )
+        self._module_api.defer_to_threadpool(
+            self._s3_pool,
+            s3_download_task,
+            self._get_s3_client(),
+            self.bucket,
+            self.prefix + path,
+            self.extra_args,
+            d,
         )
 
         # DO await on `d`, as it will resolve once a connection to S3 has been


### PR DESCRIPTION
Otherwise the download stage doesn't actually test downloading a file from S3.

Spawned from #134 passing tests, yet @erikjohnston [found](https://github.com/matrix-org/synapse-s3-storage-provider/pull/134#issuecomment-3365120372) that downloading still failed on his personal homeserver.