### PR TITLE
Pass `run_in_background` a callable; don't call it

### DIFF
--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -144,15 +144,14 @@ class S3StorageProviderBackend(StorageProvider):
         # coroutine returned by `defer_to_threadpool` is used, and therefore
         # actually run.
         run_in_background(
-            self._module_api.defer_to_threadpool(
-                self._s3_pool,
-                s3_download_task,
-                self._get_s3_client(),
-                self.bucket,
-                self.prefix + path,
-                self.extra_args,
-                d,
-            )
+            self._module_api.defer_to_threadpool,
+            self._s3_pool,
+            s3_download_task,
+            self._get_s3_client(),
+            self.bucket,
+            self.prefix + path,
+            self.extra_args,
+            d,
         )
 
         # DO await on `d`, as it will resolve once a connection to S3 has been


### PR DESCRIPTION
Follow-up to https://github.com/matrix-org/synapse-s3-storage-provider/pull/134

It helps if we use the function correctly:

```
Traceback (most recent call last):
  File "/home/synapse/src/synapse/logging/context.py", line 871, in run_in_background
    res = f(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^
TypeError: 'coroutine' object is not callable
```