### PR TITLE
Update minimum requirement for `boto3` and `botocore` dependencies to 1.36.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     py_modules=["s3_storage_provider"],
     scripts=["scripts/s3_media_upload"],
     install_requires=[
-        "boto3>=1.9.23,<2.0",
-        "botocore>=1.31.62,<2.0",
+        "boto3>=1.36.0,<2.0",
+        "botocore>=1.36.0,<2.0",
         "humanize>=4.0,<5.0",
         "psycopg2>=2.7.5,<3.0",
         "PyYAML>=5.4,<7.0",


### PR DESCRIPTION
This became required after https://github.com/matrix-org/synapse-s3-storage-provider/pull/127 made use of config options only added in 1.36.0. My bad for missing that!

boto commit that added the options: https://github.com/boto/botocore/commit/894462b46987aeab371a5525927e32c0fd0dfd57

changelog entry: https://github.com/boto/botocore/blob/40325331e046dbe894ff54dee67ad0f2925fdff7/CHANGELOG.rst#L2143