### PR TITLE
Optimisations for `s3_media_upload update-db`

### DIFF
--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -262,7 +262,10 @@ def run_update_db(synapse_db_conn, sqlite_conn, before_date):
                 )
 
             else:
-                with synapse_db_conn.cursor() as synapse_db_curs:
+                # We use a named (server-side) cursor, so that we don't have to wait
+                # for Postgres to send back all 200M items before we get started with
+                # the sync operation.
+                with synapse_db_conn.cursor('%s_items' % (mtype, )) as synapse_db_curs:
                     synapse_db_curs.execute(sql, (last_access_ts,))
                     update_count += update_db_process_rows(
                         mtype, sqlite_cur, synapse_db_curs

--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -208,8 +208,20 @@ def run_write(sqlite_conn, output_file):
 
 
 def run_update_db(synapse_db_conn, sqlite_conn, before_date):
-    """Entry point for update-db command
+    """Entry point for update-db command.
+
+    Selects all the media items in the Synapse database which haven't been accessed
+    since `before_date`, and ensures it is present in our sqlite db.
     """
+
+    # SQL queries to select the media items from the Synapse db, with the
+    # columns we will need to insert into the sqlite db.
+    #
+    # We ORDER the results to match the UNIQUE index in the sqlite db, so that
+    # we can sync the results into the sqlite db with less random I/O. (It
+    # doesn't make much difference on the Synapse DB side, since it's going to
+    # be an index scan anyway). Empirically this increases the speed of syncing by
+    # about 50x.
 
     local_sql = """
         SELECT '', media_id, media_id
@@ -217,6 +229,7 @@ def run_update_db(synapse_db_conn, sqlite_conn, before_date):
         WHERE
             COALESCE(last_access_ts, created_ts) < %s
             AND url_cache IS NULL
+        ORDER BY media_id
     """
 
     remote_sql = """
@@ -224,6 +237,7 @@ def run_update_db(synapse_db_conn, sqlite_conn, before_date):
         FROM remote_media_cache
         WHERE
             COALESCE(last_access_ts, created_ts) < %s
+        ORDER BY media_origin, media_id
     """
 
     last_access_ts = int(before_date.timestamp() * 1000)

--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -237,17 +237,18 @@ def run_update_db(synapse_db_conn, sqlite_conn, before_date):
     with sqlite_conn:
         sqlite_cur = sqlite_conn.cursor()
 
-        if isinstance(synapse_db_conn, sqlite3.Connection):
-            synapse_db_curs = synapse_db_conn.cursor()
-            for sql, mtype in ((local_sql, "local"), (remote_sql, "remote")):
+        for sql, mtype in ((local_sql, "local"), (remote_sql, "remote")):
+            print("  Syncing", mtype, "media", flush=True)
+
+            if isinstance(synapse_db_conn, sqlite3.Connection):
+                synapse_db_curs = synapse_db_conn.cursor()
                 synapse_db_curs.execute(sql.replace("%s", "?"), (last_access_ts,))
                 update_count += update_db_process_rows(
                     mtype, sqlite_cur, synapse_db_curs
                 )
 
-        else:
-            with synapse_db_conn.cursor() as synapse_db_curs:
-                for sql, mtype in ((local_sql, "local"), (remote_sql, "remote")):
+            else:
+                with synapse_db_conn.cursor() as synapse_db_curs:
                     synapse_db_curs.execute(sql, (last_access_ts,))
                     update_count += update_db_process_rows(
                         mtype, sqlite_cur, synapse_db_curs


### PR DESCRIPTION
See the individual commits for details, but in short this reduces the time taken by `update-db` from about 12 hours to about 8.