### PR TITLE
Reuse PostgreSQL configuration from Synapse's YAML file

### DIFF
--- a/scripts/s3_media_upload
+++ b/scripts/s3_media_upload
@@ -425,16 +425,8 @@ def get_homeserver_db_conn(parser, homeserver_config_path):
             database_path = database_args["database"]
             synapse_db_conn = sqlite3.connect(database=database_path)
         else:
-            # Determine the database name. "database" is a deprecated form of
-            # the option name. See https://www.psycopg.org/docs/module.html
-            database_name = database_args.get("dbname", database_args["database"])
-            synapse_db_conn = psycopg2.connect(
-                user=database_args["user"],
-                password=database_args["password"],
-                database=database_name,
-                host=database_args["host"],
-                port=database_args["port"],
-            )
+            config = {k:v for k,v in database_args.items() if not k.startswith("cp_")}
+            synapse_db_conn = psycopg2.connect(**config)
     except sqlite3.OperationalError as e:
         parser.error("Could not connect to sqlite3 database: %s" % (e,))
     except psycopg2.Error as e:


### PR DESCRIPTION
I think `psycopg2.connect()` could simply reuse the configuration found in Synapse's homeserver YAML as is, once the options starting with `cp_` are removed. This solves the following problems for me:

- https://github.com/matrix-org/synapse-s3-storage-provider/blob/0901a33e59ae8b2e38041269c75a3f51e63712c2/scripts/s3_media_upload#L430 forces me to use the deprecated `database` instead of `dbname`, or I get `KeyError: 'database'`;
- I connect to a socket with peer authentication, so I don't need both `port` and `password`