### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
     ],
+    python_requires='>=3.10, <4',
     py_modules=["s3_storage_provider"],
     scripts=["scripts/s3_media_upload"],
     install_requires=[


### PR DESCRIPTION
Python 3.9 went end-of-life in Oct 2025. In line with Synapse's dependency deprecation policy, we are dropping support for it as well.