### PR TITLE
Add Python 3.13/14 to linting CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Most CI was using "3.x", so would have been tested with 3.14 anyhow.

This just sets it for the linting job.

With this, we can consider Python 3.14 supported.