### PR TITLE
Harden our GitHub Actions CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  # In order to check out the repository.
+  contents: read
+
 jobs:
   lint:
     name: "Lint & Packaging"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: "actions/setup-python@v6"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
 
@@ -37,9 +39,11 @@ jobs:
     name: "Build and check Python package"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: "actions/setup-python@v6"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
 
@@ -63,9 +67,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: "actions/setup-python@v6"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python-version }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
     types: ["published"]
   workflow_dispatch:
 
+permissions:
+  # In order to check out the repository.
+  contents: read
+
 jobs:
   build:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,11 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: "actions/setup-python@v6"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.x"
     - name: Run synapse
-      uses: michaelkaye/setup-matrix-synapse@v1.0.6
+      uses: michaelkaye/setup-matrix-synapse@e080023c56271cab986b83db75edba570fafb88b # v1.0.6
       with: 
         uploadLogs: true
         httpPort: 8008

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
       - main
       - 'releases/*'
 
+permissions:
+  # In order to check out the repository.
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/triage_incoming.yml
+++ b/.github/workflows/triage_incoming.yml
@@ -5,24 +5,10 @@ on:
     types: [ opened ]
 
 jobs:
-  add_new_issues:
-    name: Add new issues to the triage board
-    runs-on: ubuntu-latest
-    steps:
-      - uses: octokit/graphql-action@v2.x
-        id: add_to_project
-        with:
-          headers: '{"GraphQL-Features": "projects_next_graphql"}'
-          query: |
-              mutation add_to_project($projectid:ID!,$contentid:ID!) {
-                addProjectV2ItemById(input: {projectId: $projectid contentId: $contentid}) {
-                item {
-                  id
-                  }
-                }
-              }
-          projectid: ${{ env.PROJECT_ID }}
-          contentid: ${{ github.event.issue.node_id }}
-        env:
-          PROJECT_ID: "PVT_kwDOAIB0Bs4AFDdZ"
-          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+  triage:
+    uses: matrix-org/backend-meta/.github/workflows/triage-incoming.yml@18beaf3c8e536108bd04d18e6c3dc40ba3931e28 # v2.0.3
+    with:
+      project_id: 'PVT_kwDOAIB0Bs4AFDdZ'
+      content_id: ${{ github.event.issue.node_id }}
+    secrets:
+      github_access_token: ${{ secrets.ELEMENT_BOT_TOKEN }}

--- a/.github/workflows/triage_incoming.yml
+++ b/.github/workflows/triage_incoming.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [ opened ]
 
+# This sets the permissions for the ephemeral GITHUB_TOKEN.
+# secrets.ELEMENT_BOT_TOKEN is used to authentication the project changes below.
+permissions: {}
+
 jobs:
   triage:
     uses: matrix-org/backend-meta/.github/workflows/triage-incoming.yml@18beaf3c8e536108bd04d18e6c3dc40ba3931e28 # v2.0.3

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -11,7 +11,7 @@ jobs:
     if: >
       contains(github.event.issue.labels.*.name, 'X-Needs-Info')
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2
         id: add_project
         with:
           project-url: "https://github.com/orgs/matrix-org/projects/67"
@@ -19,6 +19,7 @@ jobs:
       - name: Set status
         env:
           GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+          STEPS_ADD_PROJECT_OUTPUTS_ITEMID: ${{ steps.add_project.outputs.itemId }}
         run: |
           gh api graphql -f query='
           mutation(
@@ -41,4 +42,4 @@ jobs:
                 id
               }
             }
-          }' -f project="PVT_kwDOAIB0Bs4AFDdZ" -f item=${{ steps.add_project.outputs.itemId }} -f fieldid="PVTSSF_lADOAIB0Bs4AFDdZzgC6ZA4" -f columnid=ba22e43c --silent
+          }' -f project="PVT_kwDOAIB0Bs4AFDdZ" -f item=${STEPS_ADD_PROJECT_OUTPUTS_ITEMID} -f fieldid="PVTSSF_lADOAIB0Bs4AFDdZzgC6ZA4" -f columnid=ba22e43c --silent

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [ labeled ]
 
+# This sets the permissions for the ephemeral GITHUB_TOKEN.
+# secrets.ELEMENT_BOT_TOKEN is used to authentication the project changes below.
+permissions: {}
+
 jobs:
   move_needs_info:
     name: Move X-Needs-Info on the triage board

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+# Taken from https://github.com/zizmorcore/zizmor-action/blob/a16621b09c6db4281f81a93cb393b05dcd7b7165/README.md#usage-with-github-advanced-security-recommended
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727 # v0.5.4


### PR DESCRIPTION
Harden our GitHub Actions config according to our [internal security hardening guidelines](https://docs.google.com/document/d/1nR8oCHyovy-YNrM9sJdEz3yj6EZdjdRNnsadVV_b6cY/edit?tab=t.0), through the use of [`zizmor`](https://zizmor.sh/).

Recommended to review commit-by-commit.