### PR TITLE
fix: resolve deferred when S3 returns NoSuchKey

### DIFF
--- a/s3_storage_provider.py
+++ b/s3_storage_provider.py
@@ -236,6 +236,7 @@ def s3_download_task(s3_client, bucket, key, extra_args, deferred):
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] in ("404", "NoSuchKey",):
             logger.info("Media %s not found in S3", key)
+            reactor.callFromThread(deferred.callback, None)
             return
 
         reactor.callFromThread(deferred.errback, Failure())


### PR DESCRIPTION
## Problem

When `s3_download_task` catches a `ClientError` with code `404` or `NoSuchKey`, it logs and returns — but never calls `deferred.callback` or `deferred.errback`. This leaves the Twisted Deferred permanently unresolved, causing Synapse to hang indefinitely on any media/thumbnail request for a file that exists in the database but not in the S3 bucket. At the CDN layer this surfaces as a 504.

This is a regression from #134, which dropped `reactor.callFromThread(deferred.callback, None)` from the `NoSuchKey` branch when refactoring from` _S3DownloadThread` to a standalone function.

## Fix

One line: call `reactor.callFromThread(deferred.callback, None)` before returning in the `NoSuchKey` branch, consistent with how the success path resolves its deferred on line 245.

## Reproduction

1. Have a media record in Synapse's DB whose S3 object has been deleted.
2. Request that media (e.g. a thumbnail). Synapse hangs and never responds.

After this fix, Synapse correctly treats the missing object as not found and returns a 404 to the client.
 
Signed-off-by: Ted Roden <ted@filament.dm>
